### PR TITLE
Fix bug with orientation of preview

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -65,7 +65,7 @@ const uniqueDnaTorrance = 10000;
 const preview = {
   thumbPerRow: 5,
   thumbWidth: 50,
-  imageRatio: format.width / format.height,
+  imageRatio: format.height / format.width,
   imageName: "preview.png",
 };
 


### PR DESCRIPTION
Orientation of preview image tiles was reversed. Didn't matter for square image ratios obviously as width and height were the same.